### PR TITLE
Add ca-certificates package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ COPY . .
 RUN cargo install --path ./autokuma
  
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y libssl3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/autokuma /usr/local/bin/autokuma
 
 CMD ["autokuma"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -4,7 +4,10 @@ COPY . .
 RUN cargo install --path ./kuma-cli
  
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y libssl3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/kuma /usr/local/bin/kuma
 
 ENTRYPOINT ["kuma"]


### PR DESCRIPTION
This adds the CA bundles to the container.

This fixes https://github.com/BigBoot/AutoKuma/issues/34