### PR TITLE
Add snap packaging for the cli

### DIFF
--- a/.github/workflows/snap-build-publish.yaml
+++ b/.github/workflows/snap-build-publish.yaml
@@ -1,0 +1,35 @@
+name: Build and Publish to the Snap Store
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build snap
+      uses: snapcore/action-build@v1
+      id: build
+
+    - name: Install snap
+      run: |
+        sudo snap install --dangerous kuma_*.snap
+        snap info kuma
+        kuma --help
+
+    - name: Publish snap
+      uses: snapcore/action-publish@v1
+      env:
+        SNAP_STORE_CREDENTIALS: ${{ secrets.store-login }}
+      if: env.SNAP_STORE_CREDENTIALS
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: latest/${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docker.sock
 .vscode
 */logo.svg
 !/logo.svg
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,81 @@
+name: kuma
+adopt-info: kuma
+summary: A cli for uptime-kuma
+description: |
+  Kuma CLI is a Command Line Interface (CLI) tool for managing and interacting with Uptime Kuma (1).
+  With Kuma CLI you can easily configure, monitor and manage your applications from the command line.
+
+  All configuration options can also be specified as environment variables:
+  KUMA__URL="http://localhost:3001/"
+  KUMA__USERNAME="<username>"
+  KUMA__PASSWORD="<password>"
+  ...
+
+  Additionally Kuma CLI will read configuration from ~/snap/kuma/current/.config/kuma/config.{toml,yaml,json}.
+
+  Usage: kuma [OPTIONS] [COMMAND]
+
+  Commands:
+    monitor       Manage Monitors
+    notification  Manage Notifications
+    tag           Manage Tags
+    maintenance   Manage Maintenances
+    help          Print this message or the help of the given subcommand(s)
+
+  Options:
+        --url <URL>
+            The URL AutoKuma should use to connect to Uptime Kuma
+        --username <USERNAME>
+            The username for logging into Uptime Kuma (required unless auth is disabled)
+        --password <PASSWORD>
+            The password for logging into Uptime Kuma (required unless auth is disabled)
+        --mfa-token <MFA_TOKEN>
+            The MFA token for logging into Uptime Kuma (required if MFA is enabled)
+        --header <KEY=VALUE>
+            Add a HTTP header when connecting to Uptime Kuma
+        --connect-timeout <CONNECT_TIMEOUT>
+            The timeout for the initial connection to Uptime Kuma [default: 30.0]
+        --call-timeout <CALL_TIMEOUT>
+            The timeout for executing calls to the Uptime Kuma server [default: 30.0]
+        --format <OUTPUT_FORMAT>
+            The output format [default: json] [possible values: json, toml, yaml]
+        --pretty
+            Wether the output should be pretty printed or condensed
+    -h, --help
+            Print help
+    -V, --version
+            Print version
+
+  (1) https://uptime.kuma.pet/
+
+issues: https://github.com/BigBoot/AutoKuma/issues
+contact: https://github.com/BigBoot/AutoKuma/issues
+source-code: https://github.com/BigBoot/AutoKuma
+website: https://github.com/BigBoot/AutoKuma
+license: MIT
+
+confinement: strict
+base: core24
+
+apps:
+  kuma:
+    command: bin/kuma
+    plugs:
+      - network
+
+parts:
+  kuma:
+    plugin: rust
+    rust-channel: 1.79
+    source: .
+    source-subdir: kuma-cli
+    build-packages:
+      - libssl-dev
+    override-pull: |
+      craftctl default
+
+      git config --global --add safe.directory '*'
+      version="$(git describe --always --tags | sed -e 's/^v//;s/-/+git/;y/-/./')"
+      [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+      craftctl set version="$version"
+      craftctl set grade="$grade"


### PR DESCRIPTION
Hello,

This PR adds [snap packaging](https://snapcraft.io/about) for the cli. 
Eventually one will be able to install it with: `snap install kuma`.

Note that, as it is, it can only read a config file from `~/snap/kuma/current/.config/kuma/config.{toml,yaml,json}` due to the confinement of the snap package. This is detailed in the snap description.

The PR also include a CI job that builds the snap and optionally publishes it to the store. For that, you should create an account on [snapcraft.io](https://snapcraft.io/), register the snap name `kuma` and generate a token for the CI as detailed [here](https://github.com/snapcore/action-publish?tab=readme-ov-file#store-login).
The snap will then be automatically published as `edge` on pushes to `master` or as `candidate` on tags. Promoting the snap to `stable` should then be performed manually on the store.