### PR TITLE
Add support for mfa-secret to the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ services:
       # AUTOKUMA__KUMA__USERNAME: <username> 
       # AUTOKUMA__KUMA__PASSWORD: <password>
       # AUTOKUMA__KUMA__MFA_TOKEN: <token>
+      # AUTOKUMA__KUMA__MFA_SECRET: <secret>
       # AUTOKUMA__KUMA__HEADERS: "<header1_key>=<header1_value>,<header2_key>=<header2_value>,..."
       # AUTOKUMA__KUMA__CALL_TIMEOUT: 5
       # AUTOKUMA__KUMA__CONNECT_TIMEOUT: 5
@@ -117,6 +118,7 @@ AutoKuma can be configured using the following environment variables/config keys
 | `AUTOKUMA__KUMA__USERNAME`         | `kuma.username`         | The username for logging into Uptime Kuma (required unless auth is disabled)                                             |
 | `AUTOKUMA__KUMA__PASSWORD`         | `kuma.password`         | The password for logging into Uptime Kuma (required unless auth is disabled)                                             |
 | `AUTOKUMA__KUMA__MFA_TOKEN`        | `kuma.mfa_token`        | The MFA token for logging into Uptime Kuma (required if MFA is enabled)                                                  |
+| `AUTOKUMA__KUMA__MFA_SECRET`       | `kuma.mfa_secret`       | The MFA secret. Used to generate a tokens for logging into Uptime Kuma (alternative to a single_use mfa_token)           |
 | `AUTOKUMA__KUMA__HEADERS`          | `kuma.headers`          | List of HTTP headers to send when connecting to Uptime Kuma                                                              |
 | `AUTOKUMA__KUMA__CONNECT_TIMEOUT`  | `kuma.connect_timeout`  | The timeout for the initial connection to Uptime Kuma                                                                    |
 | `AUTOKUMA__KUMA__CALL_TIMEOUT`     | `kuma.call_timeout`     | The timeout for executing calls to the Uptime Kuma server                                                                |

--- a/kuma-cli/src/cli.rs
+++ b/kuma-cli/src/cli.rs
@@ -26,6 +26,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub mfa_token: Option<String>,
 
+    /// The MFA secret. Used to generate a tokens for logging into Uptime Kuma (alternative to a single use mfa_token).
+    #[arg(long, global = true)]
+    pub mfa_secret: Option<String>,
+
     /// Add a HTTP header when connecting to Uptime Kuma.
     #[arg(long = "header", value_name = "KEY=VALUE", global = true)]
     pub headers: Vec<String>,
@@ -80,6 +84,7 @@ impl From<Cli> for Config {
             .set_override_option("username", value.username.clone()).unwrap()
             .set_override_option("password", value.password.clone()).unwrap()
             .set_override_option("mfa_token", value.mfa_token.clone()).unwrap()
+            .set_override_option("mfa_secret", value.mfa_secret.clone()).unwrap()
             .set_override_option(
                 "headers",
                 match value.headers.is_empty() {

--- a/kuma-client/src/client.rs
+++ b/kuma-client/src/client.rs
@@ -154,7 +154,7 @@ impl Worker {
                 };
                 Some(totp.generate_current()?)
             }
-            None => self.config.mfa_secret.clone(),
+            None => self.config.mfa_token.clone(),
         })
     }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,8 @@ description: |
             The password for logging into Uptime Kuma (required unless auth is disabled)
         --mfa-token <MFA_TOKEN>
             The MFA token for logging into Uptime Kuma (required if MFA is enabled)
+        --mfa-secret <MFA_SECRET>
+            The MFA secret. Used to generate a tokens for logging into Uptime Kuma (alternative to a single use mfa_token).
         --header <KEY=VALUE>
             Add a HTTP header when connecting to Uptime Kuma
         --connect-timeout <CONNECT_TIMEOUT>


### PR DESCRIPTION
Fixes #124.

Passes through a new param called `--mfa-secret`, so that we can use the mfa secret in automation, rather than trying to use a single use token.

Note 1: I'm not a rust dev, but I gave it a go. It appears that there's no tests setup for this project, otherwise I would've added one.

Note 2: I _think_ the mfa-secret fallback was wrong, but I'm not 100% sure. I've modified it so that if the mfa-secret is not there, it'll return the mfa-token, which I think makes more sense.

Note 3: It _sometimes_ works. I'm not sure if there's an issue with server clock vs my laptop, but sometimes it'll work, and sometimes it'll fail. Not sure why.