### PR TITLE
Enable Connections to Uptime-Kuma beneath a Context Path

### DIFF
--- a/kuma-client/src/client.rs
+++ b/kuma-client/src/client.rs
@@ -971,7 +971,7 @@ impl Worker {
             .get(
                 self.config
                     .url
-                    .join(&format!("/api/status-page/{}", slug))
+                    .join(&format!("api/status-page/{}", slug))
                     .map_err(|e| Error::InvalidUrl(e.to_string()))?,
             )
             .send()


### PR DESCRIPTION
This pull request builds upon commit https://github.com/BigBoot/AutoKuma/commit/deb7e738190b338ccb95fa32aa869536a2786f17 and mirrors the fix implemented there. By removing the leading `/` form the API path, just like https://github.com/BigBoot/AutoKuma/commit/deb7e738190b338ccb95fa32aa869536a2786f17 did for the Socket.IO path, the Kuma CLI can successfully connect to Uptime-Kuma instances deployed beneath a context path. This resolves an issue regarding the interaction with status pages when connecting to a Kuma-Instance beneath a context path.

For more info, please see https://github.com/BigBoot/AutoKuma/issues/123#issuecomment-2864202035; after applying the diff that makes up this pull request, I've tested _Case 1: API at `/kuma/api/` and Socket.IO at `/kuma/socket.io/`_ again and it worked flawlessly.

Finally, thank You for this project and the effort You put into it! `:-)`