### PR TITLE
Add database shrink & clear commands

### DIFF
--- a/kuma-cli/src/cli.rs
+++ b/kuma-cli/src/cli.rs
@@ -147,6 +147,11 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: Option<crate::docker_host::Command>,
     },
+    /// Manage Statistics Database (SQLite only)
+    Database {
+        #[command(subcommand)]
+        command: Option<crate::database::Command>,
+    },
     /// Authenticate with the uptime kuma server
     Login {
         #[command(flatten)]

--- a/kuma-cli/src/database.rs
+++ b/kuma-cli/src/database.rs
@@ -1,0 +1,35 @@
+use crate::{
+    cli::Cli,
+    utils::{connect, PrintResult as _},
+};
+use clap::Subcommand;
+use kuma_client::Config;
+use serde_json::json;
+
+#[derive(Subcommand, Clone, Debug)]
+#[command(arg_required_else_help = true)]
+pub(crate) enum Command {
+    /// Get the size of the statistics database
+    Size,
+    /// Shrink (vacuum) the statistics database
+    Shrink,
+}
+
+pub(crate) async fn handle(command: &Option<Command>, config: &Config, cli: &Cli) {
+    match command {
+        Some(Command::Size) => connect(config, cli)
+            .await
+            .get_database_size()
+            .await
+            .map(|size| json!({"size": size}))
+            .print_result(cli),
+
+        Some(Command::Shrink) => connect(config, cli)
+            .await
+            .shrink_database()
+            .await
+            .print_result(cli),
+
+        None => {}
+    }
+}

--- a/kuma-cli/src/main.rs
+++ b/kuma-cli/src/main.rs
@@ -4,6 +4,7 @@ use flexi_logger::Logger;
 use kuma_client::Config;
 
 mod cli;
+mod database;
 mod docker_host;
 mod login;
 mod maintenance;
@@ -34,6 +35,7 @@ async fn main() {
         }
         Some(Commands::StatusPage { command }) => status_page::handle(command, &config, &cli).await,
         Some(Commands::DockerHost { command }) => docker_host::handle(command, &config, &cli).await,
+        Some(Commands::Database { command }) => database::handle(command, &config, &cli).await,
         Some(Commands::Login { command }) => login::handle(command, &config, &cli).await,
         None if cli.shadow => kuma_client::build::print_build_in(),
         None => {}

--- a/kuma-client/src/client.rs
+++ b/kuma-client/src/client.rs
@@ -1116,6 +1116,16 @@ impl Worker {
         Ok(msg)
     }
 
+    pub async fn get_database_size(self: &Arc<Self>) -> Result<u64> {
+        let size: u64 = self.call("getDatabaseSize", vec![], "/size", true).await?;
+        Ok(size)
+    }
+
+    pub async fn shrink_database(self: &Arc<Self>) -> Result<()> {
+        let _: bool = self.call("shrinkDatabase", vec![], "/ok", true).await?;
+        Ok(())
+    }
+
     pub async fn connect(self: &Arc<Self>) -> Result<()> {
         let mut tls_config = TlsConnector::builder();
 
@@ -1586,6 +1596,16 @@ impl Client {
         docker_host: T,
     ) -> Result<String> {
         self.worker.test_docker_host(docker_host.borrow()).await
+    }
+
+    /// Get the size of the monitor database (SQLite only)
+    pub async fn get_database_size(&self) -> Result<u64> {
+        self.worker.get_database_size().await
+    }
+
+    /// Trigger database VACUUM for the monitor database (SQLite only)
+    pub async fn shrink_database(&self) -> Result<()> {
+        self.worker.shrink_database().await
     }
 
     /// Disconnects the client from Uptime Kuma.


### PR DESCRIPTION
From [handlers/database-socket-handler.js](https://github.com/louislam/uptime-kuma/blob/master/server/socket-handlers/database-socket-handler.js)

- kuma-client: add client::get_database_size, client::shrink_database
- kuma-cli: add database > {size,shrink} command tree