### PR TITLE
Filter blank lines from `default_config`

### DIFF
--- a/autokuma/src/app_state.rs
+++ b/autokuma/src/app_state.rs
@@ -499,7 +499,7 @@ impl AppState {
                 line.split_once(":")
                     .map(|(key, value)| (key.trim().to_owned(), value.trim().to_owned()))
                     .ok_or_else(|| {
-                        Error::InvalidConfig("kuma.default_settings".to_owned(), line.to_owned())
+                        Error::InvalidConfig("default_settings".to_owned(), line.to_owned())
                     })
             })
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
Blank lines inside `default_settings` cause a cryptic parsing error along the lines of:

```
ERROR: Invalid config: Found invalid config 'kuma.default_settings': 
```

(Also note the wrong setting name; it's supposed to be `default_settings` without `kuma.`)

Example `default_config` which causes this:

```yaml
      AUTOKUMA__DEFAULT_SETTINGS: |-
        http.notification_name_list: ["tg"]
        port.notification_name_list: ["tg"]
        group.notification_name_list: []
        
        http.expiry_notification: true
        http.max_redirects: 10
        
        *.interval: 20
        *.max_retries: 3
```