### PR TITLE
feat: support _FILE env vars for secret config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,13 @@ AutoKuma can be configured using the following environment variables/config keys
 | `AUTOKUMA__KUMA__URL`              | `kuma.url`              | The URL AutoKuma should use to connect to Uptime Kuma                                                                    |
 | `AUTOKUMA__KUMA__USERNAME`         | `kuma.username`         | The username for logging into Uptime Kuma (required unless auth is disabled)                                             |
 | `AUTOKUMA__KUMA__PASSWORD`         | `kuma.password`         | The password for logging into Uptime Kuma (required unless auth is disabled)                                             |
+| `AUTOKUMA__KUMA__PASSWORD_FILE`    | N/A                     | Path to a file containing the password (alternative to direct value; cannot be set alongside PASSWORD)                  |
 | `AUTOKUMA__KUMA__MFA_TOKEN`        | `kuma.mfa_token`        | The MFA token for logging into Uptime Kuma (required if MFA is enabled)                                                  |
+| `AUTOKUMA__KUMA__MFA_TOKEN_FILE`   | N/A                     | Path to a file containing the MFA token (alternative to direct value; cannot be set alongside MFA_TOKEN)                |
 | `AUTOKUMA__KUMA__MFA_SECRET`       | `kuma.mfa_secret`       | The MFA secret. Used to generate a tokens for logging into Uptime Kuma (alternative to a single_use mfa_token)           |
+| `AUTOKUMA__KUMA__MFA_SECRET_FILE`  | N/A                     | Path to a file containing the MFA secret (alternative to direct value; cannot be set alongside MFA_SECRET)              |
 | `AUTOKUMA__KUMA__AUTH_TOKEN`       | `kuma.auth_token`       | JWT auth token received after a successful login, can be used instead of username/password                                |
+| `AUTOKUMA__KUMA__AUTH_TOKEN_FILE`  | N/A                     | Path to a file containing the auth token (alternative to direct value; cannot be set alongside AUTH_TOKEN)              |
 | `AUTOKUMA__KUMA__HEADERS`          | `kuma.headers`          | List of HTTP headers to send when connecting to Uptime Kuma                                                              |
 | `AUTOKUMA__KUMA__CONNECT_TIMEOUT`  | `kuma.connect_timeout`  | The timeout for the initial connection to Uptime Kuma                                                                    |
 | `AUTOKUMA__KUMA__CALL_TIMEOUT`     | `kuma.call_timeout`     | The timeout for executing calls to the Uptime Kuma server                                                                |

--- a/autokuma/src/main.rs
+++ b/autokuma/src/main.rs
@@ -182,6 +182,12 @@ fn init_console_subscriber() {}
 async fn main() {
     init_console_subscriber();
 
+    // Resolve secret env vars from _FILE variants before loading config
+    if let Err(e) = kuma_client::Config::resolve_secrets() {
+        eprintln!("Error resolving secret environment variables: {}", e);
+        std::process::exit(1);
+    }
+
     let config: Arc<crate::config::Config> = Arc::new(
         Config::builder()
             .add_source(File::from_str(

--- a/kuma-client/src/config.rs
+++ b/kuma-client/src/config.rs
@@ -42,19 +42,23 @@ pub struct Config {
     /// The URL for connecting to Uptime Kuma.
     pub url: Url,
 
-    /// The username for logging into Uptime Kuma (required unless auth is disabled).                      .
+    /// The username for logging into Uptime Kuma (required unless auth is disabled).
     pub username: Option<String>,
 
     /// The password for logging into Uptime Kuma (required unless auth is disabled).
+    /// Can be set via AUTOKUMA__KUMA__PASSWORD or AUTOKUMA__KUMA__PASSWORD_FILE.
     pub password: Option<String>,
 
     /// The MFA token for logging into Uptime Kuma (required if MFA is enabled).
+    /// Can be set via AUTOKUMA__KUMA__MFA_TOKEN or AUTOKUMA__KUMA__MFA_TOKEN_FILE.
     pub mfa_token: Option<String>,
 
-    /// The MFA secret. Used to generate a tokens for logging into Uptime Kuma (alternative to a single_use mfa_token).
+    /// The MFA secret. Used to generate tokens for logging into Uptime Kuma (alternative to a single_use mfa_token).
+    /// Can be set via AUTOKUMA__KUMA__MFA_SECRET or AUTOKUMA__KUMA__MFA_SECRET_FILE.
     pub mfa_secret: Option<String>,
 
-    /// JWT Auth token received after a succesfull login, can be used to as an alternative to username/password.
+    /// JWT Auth token received after a successful login, can be used as an alternative to username/password.
+    /// Can be set via AUTOKUMA__KUMA__AUTH_TOKEN or AUTOKUMA__KUMA__AUTH_TOKEN_FILE.
     pub auth_token: Option<String>,
 
     /// List of HTTP headers to send when connecting to Uptime Kuma.
@@ -90,5 +94,190 @@ impl Default for Config {
             call_timeout: 30.0,
             tls: TlsConfig::default(),
         }
+    }
+}
+
+impl Config {
+    /// Resolves secret fields from either direct values or _FILE env vars.
+    /// If both the direct value and _FILE variant are set, returns an error.
+    /// Trims trailing newlines from file contents.
+    pub fn resolve_secrets() -> std::result::Result<(), String> {
+        Self::resolve_secret_env("AUTOKUMA__KUMA__PASSWORD", "AUTOKUMA__KUMA__PASSWORD_FILE")?;
+        Self::resolve_secret_env("AUTOKUMA__KUMA__MFA_TOKEN", "AUTOKUMA__KUMA__MFA_TOKEN_FILE")?;
+        Self::resolve_secret_env("AUTOKUMA__KUMA__MFA_SECRET", "AUTOKUMA__KUMA__MFA_SECRET_FILE")?;
+        Self::resolve_secret_env("AUTOKUMA__KUMA__AUTH_TOKEN", "AUTOKUMA__KUMA__AUTH_TOKEN_FILE")?;
+        Ok(())
+    }
+
+    fn resolve_secret_env(var_name: &str, var_file_name: &str) -> std::result::Result<(), String> {
+        let has_var = std::env::var(var_name).is_ok();
+        let has_file = std::env::var(var_file_name).is_ok();
+
+        if has_var && has_file {
+            return Err(format!(
+                "both {} and {} are set; choose one",
+                var_name, var_file_name
+            ));
+        }
+
+        if has_file {
+            let file_path = std::env::var(var_file_name)
+                .map_err(|_| format!("failed to read {}", var_file_name))?;
+            let content = std::fs::read_to_string(&file_path)
+                .map_err(|e| format!("failed to read file {}: {}", file_path, e))?;
+            let trimmed = content.trim_end().to_string();
+            std::env::set_var(var_name, trimmed);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_secret_from_file() {
+        let temp_file = std::env::temp_dir().join("test_secret.txt");
+        std::fs::write(&temp_file, "secret_value\n").unwrap();
+
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD");
+        std::env::set_var("AUTOKUMA__KUMA__PASSWORD_FILE", &temp_file);
+
+        let result = Config::resolve_secret_env(
+            "AUTOKUMA__KUMA__PASSWORD",
+            "AUTOKUMA__KUMA__PASSWORD_FILE",
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__PASSWORD").unwrap(),
+            "secret_value"
+        );
+
+        std::fs::remove_file(&temp_file).unwrap();
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD");
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD_FILE");
+    }
+
+    #[test]
+    fn test_resolve_secret_strips_newline() {
+        let temp_file = std::env::temp_dir().join("test_secret_newline.txt");
+        std::fs::write(&temp_file, "value_with_newline\n").unwrap();
+
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN");
+        std::env::set_var("AUTOKUMA__KUMA__MFA_TOKEN_FILE", &temp_file);
+
+        let result = Config::resolve_secret_env(
+            "AUTOKUMA__KUMA__MFA_TOKEN",
+            "AUTOKUMA__KUMA__MFA_TOKEN_FILE",
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__MFA_TOKEN").unwrap(),
+            "value_with_newline"
+        );
+        assert!(!std::env::var("AUTOKUMA__KUMA__MFA_TOKEN")
+            .unwrap()
+            .ends_with('\n'));
+
+        std::fs::remove_file(&temp_file).unwrap();
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN_FILE");
+    }
+
+    #[test]
+    fn test_conflict_both_set() {
+        std::env::set_var("AUTOKUMA__KUMA__PASSWORD", "direct_value");
+        std::env::set_var("AUTOKUMA__KUMA__PASSWORD_FILE", "/tmp/some_file");
+
+        let result = Config::resolve_secret_env(
+            "AUTOKUMA__KUMA__PASSWORD",
+            "AUTOKUMA__KUMA__PASSWORD_FILE",
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("both AUTOKUMA__KUMA__PASSWORD and AUTOKUMA__KUMA__PASSWORD_FILE are set"));
+
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD");
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD_FILE");
+    }
+
+    #[test]
+    fn test_file_not_found() {
+        std::env::remove_var("AUTOKUMA__KUMA__AUTH_TOKEN");
+        std::env::set_var("AUTOKUMA__KUMA__AUTH_TOKEN_FILE", "/nonexistent/file");
+
+        let result = Config::resolve_secret_env(
+            "AUTOKUMA__KUMA__AUTH_TOKEN",
+            "AUTOKUMA__KUMA__AUTH_TOKEN_FILE",
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("failed to read file"));
+
+        std::env::remove_var("AUTOKUMA__KUMA__AUTH_TOKEN_FILE");
+    }
+
+    #[test]
+    fn test_resolve_all_secrets() {
+        let temp_dir = std::env::temp_dir();
+        let password_file = temp_dir.join("password.txt");
+        let mfa_token_file = temp_dir.join("mfa_token.txt");
+        let mfa_secret_file = temp_dir.join("mfa_secret.txt");
+        let auth_token_file = temp_dir.join("auth_token.txt");
+
+        std::fs::write(&password_file, "password123\n").unwrap();
+        std::fs::write(&mfa_token_file, "mfa123\n").unwrap();
+        std::fs::write(&mfa_secret_file, "secret456\n").unwrap();
+        std::fs::write(&auth_token_file, "token789\n").unwrap();
+
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_SECRET");
+        std::env::remove_var("AUTOKUMA__KUMA__AUTH_TOKEN");
+
+        std::env::set_var("AUTOKUMA__KUMA__PASSWORD_FILE", &password_file);
+        std::env::set_var("AUTOKUMA__KUMA__MFA_TOKEN_FILE", &mfa_token_file);
+        std::env::set_var("AUTOKUMA__KUMA__MFA_SECRET_FILE", &mfa_secret_file);
+        std::env::set_var("AUTOKUMA__KUMA__AUTH_TOKEN_FILE", &auth_token_file);
+
+        let result = Config::resolve_secrets();
+
+        assert!(result.is_ok());
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__PASSWORD").unwrap(),
+            "password123"
+        );
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__MFA_TOKEN").unwrap(),
+            "mfa123"
+        );
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__MFA_SECRET").unwrap(),
+            "secret456"
+        );
+        assert_eq!(
+            std::env::var("AUTOKUMA__KUMA__AUTH_TOKEN").unwrap(),
+            "token789"
+        );
+
+        std::fs::remove_file(&password_file).unwrap();
+        std::fs::remove_file(&mfa_token_file).unwrap();
+        std::fs::remove_file(&mfa_secret_file).unwrap();
+        std::fs::remove_file(&auth_token_file).unwrap();
+
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD");
+        std::env::remove_var("AUTOKUMA__KUMA__PASSWORD_FILE");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_TOKEN_FILE");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_SECRET");
+        std::env::remove_var("AUTOKUMA__KUMA__MFA_SECRET_FILE");
+        std::env::remove_var("AUTOKUMA__KUMA__AUTH_TOKEN");
+        std::env::remove_var("AUTOKUMA__KUMA__AUTH_TOKEN_FILE");
     }
 }


### PR DESCRIPTION
## Feature: Support _FILE Environment Variables for Secret Configuration

This PR adds support for reading secrets from files via `_FILE` environment variables, which is a standard pattern for Docker Compose secrets and Kubernetes secret mounts.

### Changes

1. **kuma-client/src/config.rs**: Added `Config::resolve_secrets()` and `Config::resolve_secret_env()` methods that:
   - Read secret values from `_FILE` variants if the regular env var is not set
   - Support all four secret fields: PASSWORD, MFA_TOKEN, MFA_SECRET, AUTH_TOKEN
   - Trim trailing newlines (common with Docker secret files)
   - Return clear error messages if both direct and `_FILE` variants are set
   - Includes comprehensive unit tests

2. **autokuma/src/main.rs**: Call `Config::resolve_secrets()` before deserializing the config to ensure `_FILE` values are available to the config builder.

3. **README.md**: Document the new `_FILE` env vars in the configuration table.

### Supported Environment Variables

- `AUTOKUMA__KUMA__PASSWORD_FILE` (reads from file instead of `AUTOKUMA__KUMA__PASSWORD`)
- `AUTOKUMA__KUMA__MFA_TOKEN_FILE` (reads from file instead of `AUTOKUMA__KUMA__MFA_TOKEN`)
- `AUTOKUMA__KUMA__MFA_SECRET_FILE` (reads from file instead of `AUTOKUMA__KUMA__MFA_SECRET`)
- `AUTOKUMA__KUMA__AUTH_TOKEN_FILE` (reads from file instead of `AUTOKUMA__KUMA__AUTH_TOKEN`)

### Behavior

- **File reading**: Reads the entire contents of the specified file
- **Newline trimming**: Strips trailing whitespace (particularly newlines) to handle Docker secret formatting
- **Conflict detection**: If both `X` and `X_FILE` are set, the application exits with a clear error message
- **Backward compatible**: All existing direct env var usage continues to work unchanged

### Use Cases

This pattern enables secure secret management in:
- Docker Compose with `secrets:`
- Docker Swarm with secret objects
- Kubernetes with mounted secret volumes
- CI/CD pipelines using secret files

### Testing

The implementation includes tests for:
- Reading from file successfully
- Stripping trailing newlines
- Detecting conflicts when both variants are set
- File-not-found error handling
- Resolving all four secrets together

Fixes: proxmox-manager#157, proxmox-manager#96